### PR TITLE
Report wrong reference to the "Appropriateness" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,18 @@ Error found and reported by Ulrich Cech. This error also appears in the 1st edit
 The "x" was printed in the wrong column. Component diagrams are indeed **very useful** in diagramming or modeling software architectures.
 So the correct answer here should be "false".
 
+
+#### Page 28, 35, 108: Reference to the "Appropriateness" section
+<small>
+Error found and reported by Safa Keskin.
+</small>
+
+Original text:
+
+>See Part III "Appropriateness" on page 159
+
+or
+
+>See Part III, "Appropriateness" on page 159
+
+Page number should be corrected to 161, hence the "Appropriateness" section is placed on that page.


### PR DESCRIPTION
The page number for the "Appropriateness" section is incorrect on 3 pages, even though it's correct on another page (See page 111). This PR is intended to include make this problem recognized.